### PR TITLE
Fix wrong Facade class name in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
                 "Meema\\CloudFront\\Providers\\CloudFrontServiceProvider"
             ],
             "aliases": {
-                "CloudFront": "Meema\\CloudFront\\Facades\\CloudFrontFacade"
+                "CloudFront": "Meema\\CloudFront\\Facades\\CloudFront"
             }
         }
     }


### PR DESCRIPTION
composer.json has wrong class name

```
            "aliases": {
                "CloudFront": "Meema\\CloudFront\\Facades\\CloudFrontFacade"
            }
```

Should be
`"Meema\\CloudFront\\Facades\\CloudFront"`